### PR TITLE
Fix truncated normal call with empty tensor

### DIFF
--- a/hmsc/updaters/updateZ.py
+++ b/hmsc/updaters/updateZ.py
@@ -84,9 +84,12 @@ def updateZ(params, data, rLHyperparams, poisson_preupdate_z=True, poisson_updat
     if truncated_normal_library == "tfd":
       ZProbit = tfd.TruncatedNormal(loc=LP, scale=sigmaP, low=low, high=high).sample(name="z-ZProbit")
     elif truncated_normal_library == "tf":
-      samTN = parameterized_truncated_normal(shape=[ny*nsP], means=tf.reshape(LP,[ny*nsP]), stddevs=tf.tile(sigmaP,[ny]), 
-                                              minvals=tf.reshape(low,[ny*nsP]), maxvals=tf.reshape(high,[ny*nsP]), dtype=dtype,
-                                              name="z-samTN")
+      if nsP == 0:
+        samTN = tf.convert_to_tensor((), dtype=dtype)
+      else:
+        samTN = parameterized_truncated_normal(shape=[ny*nsP], means=tf.reshape(LP,[ny*nsP]), stddevs=tf.tile(sigmaP,[ny]),
+                                               minvals=tf.reshape(low,[ny*nsP]), maxvals=tf.reshape(high,[ny*nsP]), dtype=dtype,
+                                               name="z-samTN")
       ZProbit = tf.reshape(samTN, [ny,nsP])
     elif truncated_normal_library == "scipy":
       loc, scale = tf.reshape(LP,[ny*nsP]), tf.tile(sigmaP,[ny])


### PR DESCRIPTION
This PR will fix the error `./tensorflow/core/util/gpu_launch_config.h:129] Check failed: work_element_count > 0 (0 vs. 0)` that comes when `parameterized_truncated_normal()` is called with empty tensors.